### PR TITLE
Updated blog sidebars.yaml

### DIFF
--- a/developer-portal/blog/sidebars.yaml
+++ b/developer-portal/blog/sidebars.yaml
@@ -11,4 +11,4 @@
     - label: Introducing XRPL 1.8.5
       page: 2022/rippled-1.8.5.md
     - label: Introducing XRPL 1.8.4
-      page: rippled-1.8.4.md
+      page: 2022/rippled-1.8.4.md

--- a/developer-portal/blog/sidebars.yaml
+++ b/developer-portal/blog/sidebars.yaml
@@ -1,15 +1,14 @@
-blog:
-  - page: developer-portal/blog/index.md
-  - group: 2022
-    expanded: true
-    pages:
-      - label: Introducing XRP Ledger 1.9.0
-        page: developer-portal/blog/2022/rippled-1.9.0.md
-      - label: Introducing Clio Beta
-        page: developer-portal/blog/2022/introducing-clio.md
-      - label: Announcing NFT-Devnet Reset
-        page: developer-portal/blog/2022/nft-devnet-reset.md
-      - label: Introducing XRPL 1.8.5
-        page: developer-portal/blog/2022/rippled-1.8.5.md
-      - label: Introducing XRPL 1.8.4
-        page: developer-portal/blog/2022/rippled-1.8.4.md
+- page: index.md
+- group: 2022
+  expanded: true
+  pages:
+    - label: Introducing XRP Ledger 1.9.0
+      page: 2022/rippled-1.9.0.md
+    - label: Introducing Clio Beta
+      page: 2022/introducing-clio.md
+    - label: Announcing NFT-Devnet Reset
+      page: 2022/nft-devnet-reset.md
+    - label: Introducing XRPL 1.8.5
+      page: 2022/rippled-1.8.5.md
+    - label: Introducing XRPL 1.8.4
+      page: rippled-1.8.4.md


### PR DESCRIPTION
The paths to the files needed to be relative to where the sidebars file was. Plus the group name at the top wasn't required.