### PR TITLE
XRPL Card Deck component w/ example usage

### DIFF
--- a/_components/XRPLCardDeck.tsx
+++ b/_components/XRPLCardDeck.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+import { Link } from '@redocly/developer-portal/ui';
+
+export function XRPLCardDeck(props) {
+  const { cards, cols, children } = props;
+  let classes = "row row-cols-2 row-cols-lg-4 card-deck mt-10 autocards";
+  if (typeof cols != "undefined") {
+    const [mobile_cols, desktop_cols] = cols.split("/");
+    classes = `row row-cols-${mobile_cols.trim()} row-cols-lg-${desktop_cols.trim()} card-deck mt-10 autocards`
+  }
+
+  return (
+    <div className={classes}>
+      {children} {}
+    </div>
+  )
+
+}
+
+export function DeckCard(props) {
+  const {title, children, to, external} = props;
+
+  return (
+    <Link className="card" to={to} external={external}>
+      <div className="card-body">
+        <h4 className="card-title h5">{title}</h4>
+        <p className="card-text">
+          {children} {}
+        </p>
+      </div>
+      <div className="card-footer">&nbsp;</div>
+    </Link>
+  );
+}

--- a/docs/sidebars.yaml
+++ b/docs/sidebars.yaml
@@ -8,7 +8,7 @@
     - page: concepts/introduction/txn-and-requests.md
     - page: concepts/introduction/other-topics-placeholder.md
 - group: Tutorials
-  page: tutorials/index.md
+  page: tutorials/index.mdx
   expanded: false
   pages:
     - group: Quickstart

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,7 +1,0 @@
----
-title: XRP Ledger Tutorials
----
-
-# Tutorials
-
-The XRP Ledger tutorials walk you through the steps to learn and get started with the XRP Ledger and to use the ledger for advanced use cases.

--- a/docs/tutorials/index.mdx
+++ b/docs/tutorials/index.mdx
@@ -1,0 +1,20 @@
+---
+title: XRP Ledger Tutorials
+---
+import { XRPLCardDeck, DeckCard } from "../../_components/XRPLCardDeck";
+
+# Tutorials
+
+The XRP Ledger tutorials walk you through the steps to learn and get started with the XRP Ledger and to use the ledger for advanced use cases.
+
+<XRPLCardDeck cols="1/3">
+  <DeckCard title="Quickstart" to="./quickstart/index.md">
+    Placeholder description for the Quickstart goes here, <em>allowing HTML</em> but **not markdown**.<br /><br />Linebreaks are ignored so you'll need tags to force them with HTML.
+  </DeckCard>
+  <DeckCard title="XRPL.org">
+    This is the second card. Don't put links or regular line breaks in descriptions.
+  </DeckCard>
+  <DeckCard title="Ripple Website" to="https://ripple.com" external>
+    This card is an external link to Ripple's website.
+  </DeckCard>
+</XRPLCardDeck>

--- a/static/css/fixes.css
+++ b/static/css/fixes.css
@@ -455,28 +455,28 @@ html.light .top-banner .btn-outline-secondary:not(:disabled):not(.disabled):hove
 
 /* photo banner */
 #container-scroll {
-  height:160px; 
-  position:relative; 
+  height:160px;
+  position:relative;
   overflow:hidden;
   margin-top: 80px;
   margin-bottom: 64px;
 }
 
 .photobanner {
-  position:absolute; 
-  top:0px; 
-  left:0px; 
-  overflow:hidden; 
+  position:absolute;
+  top:0px;
+  left:0px;
+  overflow:hidden;
   white-space: nowrap;
   animation: bannermove 40s linear infinite;
 }
 
 .photobanner-bottom {
-  top:112px; 
+  top:112px;
 }
 
-.photobanner img {    
-  margin: 0 0.5em 
+.photobanner img {
+  margin: 0 0.5em
 }
 
 @keyframes bannermove {
@@ -719,7 +719,7 @@ html.light .top-banner .btn-outline-secondary:not(:disabled):not(.disabled):hove
   font-weight:bold;
 }
 h1{
-  font-size: 3.875rem; 
+  font-size: 3.875rem;
 }
 .light .eyebrow{
   color:#111112
@@ -759,4 +759,58 @@ h1{
 }
 .page-uses .biz-logo {
   max-width:50% !important;
+}
+
+/* Card decks in mdx contents */
+.autocards a.card p,
+.autocards a.card:hover p {
+  color: white;
+}
+.autocards .card-footer {
+  height: 1rem;
+}
+
+.autocards a.card.external-url::after {
+  /* Hide Redocly external link icon */
+  display:none;
+}
+
+.autocards a.card.external-url .card-title::after {
+  content: "\00a0";
+  background-image: url(../img/icons/arrow-up-right.svg);
+  background-repeat: no-repeat;
+  display: inline-block;
+  background-size: 16px;
+  padding: 0 4px 0 8px;
+  width: 24px;
+  background-position: left 4px top 8px;
+  transition: background-position 100ms ease-in-out;
+}
+.autocards a.card.external-url:hover .card-title::after {
+  background-position: left 8px top 4px;
+}
+
+.autocards .card:nth-child(1) .card-footer {
+  background-image: url(../img/cards/4col-orange.svg);
+}
+.autocards .card:nth-child(2) .card-footer {
+  background-image: url(../img/cards/4col-light-blue.svg);
+}
+.autocards .card:nth-child(3) .card-footer {
+  background-image: url(../img/cards/4col-green-2.svg);
+}
+.autocards .card:nth-child(4) .card-footer {
+  background-image: url(../img/cards/4col-magenta-3.svg);
+}
+.autocards .card:nth-child(5) .card-footer {
+  background-image: url(../img/cards/4col-yellow.svg);
+}
+.autocards .card:nth-child(6) .card-footer {
+  background-image: url(../img/cards/4col-blue-green-2.svg);
+}
+.autocards .card:nth-child(7) .card-footer {
+  background-image: url(../img/cards/4col-purple-blue.svg);
+}
+.autocards .card:nth-child(8) .card-footer {
+  background-image: url(../img/cards/4col-orange-yellow.svg);
 }


### PR DESCRIPTION
- [x] Implements new `XRPLCardDeck` and `DeckCard` components so that mdx pages can include new-style cards
- [x] Adds related styles
- [x] Converts tutorials landing page to an example of usage (this page was previously a placeholder anyway).

After merging this PR, you'll be able to add new card decks in the middle of any mdx content by following a similar syntax to the `docs/tutorials/index.mdx` page:

1. Import the components (the number of `../`'s needed depends on how deep your page is in the directory tree)
2. Add a `<XRPLCardDeck>` element to wrap all the cards. Blank lines before & after are important. Blank lines inside might cause problems.
3. Add `<DeckCard title="Card Title" to="link">Description here</DeckCard>` elements for each card. The "to" link can be a complete URL or a relative path, like regular Markdown links in Redocly.

The `cols` property of `XRPLCardDeck` is optional and indicates how many columns to use for the deck on mobile/desktop. We don't have styles in place for all possible combinations: mobile can be 1 or 2 columns and desktop can be 3 or 4 columns, so your options are "1/3", "2/4", "1/4", and "2/3". The default is "2/4" meaning 2 columns on mobile and 4 columns on desktop.

I added styles to provide card-footer images for up to 8 cards (reusing the images we have in the site already¹). Theoretically we have enough images for at least 20 but I didn't feel like going that far. They're not randomized so the first card will always be orange, the second light-blue, etc.

There are some quirks with Redocly and MDX; you should't create links or use markdown syntax inside the card descriptions, but you can use HTML² and line breaks can sometimes cause weird stuff to happen. Also, this is not new to here, but for external links, if the title text is just the wrong length then the "external link" arrow icon will be the only thing that gets pushed down to the next line, which is kind of ugly but it's unavoidable that it'll happen sometimes.

¹<smaller>fun fact, on the pages we have prior to this, every card footer image is unique. But making enough for every link on every table of contents page feels like it would be way too much effort to do by hand. I think hypothetically it would be possible to write a program that generates similar images procedurally, but that feels pretty extraneous here</smaller>
²<smaller>technically I think it's React-style almost-HTML, so you need to close your `<img>` tags and use `className` instead of `class`, but that usually shouldn't matter.</smaller>
