### PR TITLE
change code in text color

### DIFF
--- a/static/css/fixes.css
+++ b/static/css/fixes.css
@@ -1129,4 +1129,13 @@ margin-bottom:0px!important;
 .page-xrpl-overview h1{
   font-size: 3.875rem;
 }
-
+code {
+  color: #5beb9d!important;
+  border: none !important;
+  background-color: #5beb9d26!important;
+  font-family: 'Space Mono'!important;
+}
+.light code{ 
+  color: #111112!important;
+  background-color: #11111212!important;
+}

--- a/static/css/fixes.css
+++ b/static/css/fixes.css
@@ -1130,10 +1130,7 @@ margin-bottom:0px!important;
   font-size: 3.875rem;
 }
 code {
-  color: #5beb9d!important;
   border: none !important;
-  background-color: #5beb9d26!important;
-  font-family: 'Space Mono'!important;
 }
 .light code{ 
   color: #111112!important;

--- a/theme.ts
+++ b/theme.ts
@@ -155,10 +155,10 @@ export const theme = {
     // },
     code: {
       fontSize: '13px',
-      fontFamily: '"Source Code Pro", sans-serif',
+      fontFamily: "Space Mono",
       // fontWeight: ({ typography }) => typography.fontWeightRegular,
-      color: '#e53935',
-      backgroundColor: 'rgba(38, 50, 56, 0.04)',
+      color: '#5beb9d',
+      backgroundColor: '#5beb9d26',
       wrap: false,
     },
     links: {


### PR DESCRIPTION
change code in text color according to design https://www.figma.com/file/BhSopy6K5jWIX8c93bnSEO/Docs-(Redocly)-Redesign?node-id=236%3A3314

link to issue https://github.com/ripple/xrpl-org-dev-portal/pull/22

Before: 

<img width="934" alt="Screen Shot 2022-09-06 at 2 15 06 PM" src="https://user-images.githubusercontent.com/9340787/188739503-4dfbb667-f6bf-4295-a917-dda7ae9def52.png">

<img width="910" alt="Screen Shot 2022-09-06 at 2 15 00 PM" src="https://user-images.githubusercontent.com/9340787/188739508-fbea1d2c-e1bc-4a4f-9534-a6bf3b6266ae.png">





After: 
<img width="907" alt="Screen Shot 2022-09-06 at 2 17 17 PM" src="https://user-images.githubusercontent.com/9340787/188739812-22fade40-dd98-4dfc-b2c8-0aca611678de.png">
<img width="896" alt="Screen Shot 2022-09-06 at 2 17 21 PM" src="https://user-images.githubusercontent.com/9340787/188739781-234cd24c-13f8-4366-bf97-c13abf165d8b.png">



