### PR TITLE
Add zeroes to tx fee

### DIFF
--- a/_components/pages/XRPOverview.tsx
+++ b/_components/pages/XRPOverview.tsx
@@ -184,7 +184,7 @@ export default function XRPOverview() {
                     </tr>
                     <tr>
                       <td>Low-Cost</td>
-                      <td>0.000012/tx</td>
+                      <td>0.000010/tx</td>
                       <td>$0.50/tx</td>
                     </tr>
                     <tr>

--- a/_components/pages/XRPOverview.tsx
+++ b/_components/pages/XRPOverview.tsx
@@ -184,7 +184,7 @@ export default function XRPOverview() {
                     </tr>
                     <tr>
                       <td>Low-Cost</td>
-                      <td>$0.0002/tx</td>
+                      <td>0.000002/tx</td>
                       <td>$0.50/tx</td>
                     </tr>
                     <tr>

--- a/_components/pages/XRPOverview.tsx
+++ b/_components/pages/XRPOverview.tsx
@@ -184,7 +184,7 @@ export default function XRPOverview() {
                     </tr>
                     <tr>
                       <td>Low-Cost</td>
-                      <td>0.000002/tx</td>
+                      <td>0.000012/tx</td>
                       <td>$0.50/tx</td>
                     </tr>
                     <tr>


### PR DESCRIPTION
Remove the $ sign and add two zeroes to the transaction fee in the benefits table.